### PR TITLE
Rewritten hallof fame so it uses new queries.

### DIFF
--- a/frontend/src/components/hallOfFame/hallOfFameHeader.tsx
+++ b/frontend/src/components/hallOfFame/hallOfFameHeader.tsx
@@ -1,0 +1,29 @@
+import { Styles } from "../../utils/Styles";
+
+const styles: Styles = {
+  header: {
+    position: "sticky",
+    top: 0,
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr 3fr 2fr 1fr",
+    gap: 12,
+    width: "100%",
+    padding: "12px 0",
+    backgroundColor: "white",
+    borderBottom: "1px solid #ccc",
+    fontWeight: "bold",
+    zIndex: 100,
+  },
+};
+
+export default function HallOfFameHeader() {
+  return (
+    <div style={styles.header}>
+      <div>Pozycja</div>
+      <div> </div>
+      <div>Nick</div>
+      <div>Poziom</div>
+      <div>Punkty</div>
+    </div>
+  );
+}

--- a/frontend/src/components/hallOfFame/hallOfFameHeader.tsx
+++ b/frontend/src/components/hallOfFame/hallOfFameHeader.tsx
@@ -5,7 +5,7 @@ const styles: Styles = {
     position: "sticky",
     top: 0,
     display: "grid",
-    gridTemplateColumns: "1fr 1fr 3fr 2fr 1fr",
+    gridTemplateColumns: "2fr 3fr 2fr 1fr",
     gap: 12,
     width: "100%",
     padding: "12px 0",
@@ -20,7 +20,6 @@ export default function HallOfFameHeader() {
   return (
     <div style={styles.header}>
       <div>Pozycja</div>
-      <div> </div>
       <div>Nick</div>
       <div>Poziom</div>
       <div>Punkty</div>

--- a/frontend/src/components/hallOfFame/hallOfFameRow.tsx
+++ b/frontend/src/components/hallOfFame/hallOfFameRow.tsx
@@ -37,7 +37,7 @@ export default function HallOfFameRow({
         border: isCurrentUser ? "2px solid blue" : "1px solid black",
       }}
     >
-      <div>{index + 1}</div>
+      <div>{`${index + 1}.`}</div>
       <div>
         <div style={styles.logoPlaceholder} />
       </div>

--- a/frontend/src/components/hallOfFame/hallOfFameRow.tsx
+++ b/frontend/src/components/hallOfFame/hallOfFameRow.tsx
@@ -1,0 +1,49 @@
+import { HallOfFameQuery } from "../../graphql/hallOfFame.graphql.types";
+import { Styles } from "../../utils/Styles";
+
+const styles: Styles = {
+  item: {
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr 3fr 2fr 1fr",
+    alignItems: "center",
+    border: "1px solid black",
+    gap: 12,
+    padding: 12,
+    boxSizing: "border-box",
+    width: "100%",
+  },
+  logoPlaceholder: {
+    width: 30,
+    height: 30,
+    borderRadius: "50%",
+    backgroundColor: "gray",
+  },
+};
+
+export default function HallOfFameRow({
+  student,
+  index,
+  isCurrentUser,
+}: {
+  student: HallOfFameQuery["hallOfFame"][number];
+  index: number;
+  isCurrentUser: boolean;
+}) {
+  return (
+    <div
+      id={`student-${student.userId}`}
+      style={{
+        ...styles.item,
+        border: isCurrentUser ? "2px solid blue" : "1px solid black",
+      }}
+    >
+      <div>{index + 1}</div>
+      <div>
+        <div style={styles.logoPlaceholder} />
+      </div>
+      <div>{student.nick}</div>
+      <div>{student.levelName}</div>
+      <div>{student.sumOfPoints}</div>
+    </div>
+  );
+}

--- a/frontend/src/graphql/hallOfFame.graphql
+++ b/frontend/src/graphql/hallOfFame.graphql
@@ -1,0 +1,14 @@
+query hallOfFame($editionId: bigint!) {
+  hallOfFame(
+    where: { editionId: { _eq: $editionId } }
+    orderBy: [{ sumOfPoints: DESC }, { nick: ASC }]
+  ) {
+    editionId
+    imageFileId
+    levelId
+    levelName
+    nick
+    sumOfPoints
+    userId
+  }
+}

--- a/frontend/src/graphql/hallOfFame.graphql
+++ b/frontend/src/graphql/hallOfFame.graphql
@@ -1,4 +1,4 @@
-query hallOfFame($editionId: bigint!) {
+query hallOfFame($editionId: bigint) {
   hallOfFame(
     where: { editionId: { _eq: $editionId } }
     orderBy: [{ sumOfPoints: DESC }, { nick: ASC }]

--- a/frontend/src/graphql/hallOfFame.graphql.types.ts
+++ b/frontend/src/graphql/hallOfFame.graphql.types.ts
@@ -4,7 +4,7 @@ import { gql } from "@apollo/client";
 import * as Apollo from "@apollo/client";
 const defaultOptions = {} as const;
 export type HallOfFameQueryVariables = Types.Exact<{
-  editionId: Types.Scalars["bigint"]["input"];
+  editionId?: Types.InputMaybe<Types.Scalars["bigint"]["input"]>;
 }>;
 
 export type HallOfFameQuery = {
@@ -22,7 +22,7 @@ export type HallOfFameQuery = {
 };
 
 export const HallOfFameDocument = gql`
-  query hallOfFame($editionId: bigint!) {
+  query hallOfFame($editionId: bigint) {
     hallOfFame(
       where: { editionId: { _eq: $editionId } }
       orderBy: [{ sumOfPoints: DESC }, { nick: ASC }]
@@ -55,14 +55,10 @@ export const HallOfFameDocument = gql`
  * });
  */
 export function useHallOfFameQuery(
-  baseOptions: Apollo.QueryHookOptions<
+  baseOptions?: Apollo.QueryHookOptions<
     HallOfFameQuery,
     HallOfFameQueryVariables
-  > &
-    (
-      | { variables: HallOfFameQueryVariables; skip?: boolean }
-      | { skip: boolean }
-    ),
+  >,
 ) {
   const options = { ...defaultOptions, ...baseOptions };
   return Apollo.useQuery<HallOfFameQuery, HallOfFameQueryVariables>(

--- a/frontend/src/graphql/hallOfFame.graphql.types.ts
+++ b/frontend/src/graphql/hallOfFame.graphql.types.ts
@@ -1,0 +1,107 @@
+import * as Types from "../__generated__/schema.graphql.types";
+
+import { gql } from "@apollo/client";
+import * as Apollo from "@apollo/client";
+const defaultOptions = {} as const;
+export type HallOfFameQueryVariables = Types.Exact<{
+  editionId: Types.Scalars["bigint"]["input"];
+}>;
+
+export type HallOfFameQuery = {
+  __typename?: "query_root";
+  hallOfFame: Array<{
+    __typename?: "HallOfFame";
+    editionId?: string | null;
+    imageFileId?: string | null;
+    levelId?: string | null;
+    levelName?: string | null;
+    nick?: string | null;
+    sumOfPoints?: string | null;
+    userId?: string | null;
+  }>;
+};
+
+export const HallOfFameDocument = gql`
+  query hallOfFame($editionId: bigint!) {
+    hallOfFame(
+      where: { editionId: { _eq: $editionId } }
+      orderBy: [{ sumOfPoints: DESC }, { nick: ASC }]
+    ) {
+      editionId
+      imageFileId
+      levelId
+      levelName
+      nick
+      sumOfPoints
+      userId
+    }
+  }
+`;
+
+/**
+ * __useHallOfFameQuery__
+ *
+ * To run a query within a React component, call `useHallOfFameQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHallOfFameQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHallOfFameQuery({
+ *   variables: {
+ *      editionId: // value for 'editionId'
+ *   },
+ * });
+ */
+export function useHallOfFameQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    HallOfFameQuery,
+    HallOfFameQueryVariables
+  > &
+    (
+      | { variables: HallOfFameQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    ),
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<HallOfFameQuery, HallOfFameQueryVariables>(
+    HallOfFameDocument,
+    options,
+  );
+}
+export function useHallOfFameLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    HallOfFameQuery,
+    HallOfFameQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<HallOfFameQuery, HallOfFameQueryVariables>(
+    HallOfFameDocument,
+    options,
+  );
+}
+export function useHallOfFameSuspenseQuery(
+  baseOptions?: Apollo.SuspenseQueryHookOptions<
+    HallOfFameQuery,
+    HallOfFameQueryVariables
+  >,
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<HallOfFameQuery, HallOfFameQueryVariables>(
+    HallOfFameDocument,
+    options,
+  );
+}
+export type HallOfFameQueryHookResult = ReturnType<typeof useHallOfFameQuery>;
+export type HallOfFameLazyQueryHookResult = ReturnType<
+  typeof useHallOfFameLazyQuery
+>;
+export type HallOfFameSuspenseQueryHookResult = ReturnType<
+  typeof useHallOfFameSuspenseQuery
+>;
+export type HallOfFameQueryResult = Apollo.QueryResult<
+  HallOfFameQuery,
+  HallOfFameQueryVariables
+>;

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -1,8 +1,9 @@
 import { createBrowserRouter } from "react-router-dom";
-import { HallOfFame, Welcome } from "../screens";
 import { Root } from "../components";
 import { paths } from "./paths";
 import { StudentProfile } from "../screens/StudentProfile";
+import HallOfFame from "../screens/HallOfFame";
+import { Welcome } from "../screens/Welcome";
 
 export const routes = createBrowserRouter([
   {
@@ -24,7 +25,7 @@ export const routes = createBrowserRouter([
       },
       {
         path: paths.HallOfFame,
-        element: <HallOfFame studentId={"6"} />,
+        element: <HallOfFame />,
       },
     ],
   },

--- a/frontend/src/screens/HallOfFame.tsx
+++ b/frontend/src/screens/HallOfFame.tsx
@@ -41,7 +41,7 @@ export default function HallOfFame() {
   const { selectedEdition } = useEditionSelection();
 
   const { loading, error, data } = useHallOfFameQuery({
-    variables: { editionId: selectedEdition?.editionId as string },
+    variables: { editionId: selectedEdition?.editionId },
     skip: !selectedEdition,
   });
 

--- a/frontend/src/screens/HallOfFame.tsx
+++ b/frontend/src/screens/HallOfFame.tsx
@@ -1,72 +1,90 @@
-import { useRef } from "react";
-import { getStudents } from "../api";
-import { Student, Styles } from "../utils";
+import { useRef, useEffect, useCallback } from "react";
+import { useUser } from "../hooks/useUser";
+import { useHallOfFameQuery } from "../graphql/hallOfFame.graphql.types";
+import { useEditionSelection } from "../hooks/useEditionSelection";
+import { Roles, Styles } from "../utils";
+import HallOfFameRow from "../components/hallOfFame/hallOfFameRow";
+import HallOfFameHeader from "../components/hallOfFame/hallOfFameHeader";
 
 const styles: Styles = {
   container: {
+    position: "relative",
     display: "flex",
     flexDirection: "column",
     gap: 12,
     margin: 12,
+    minHeight: "100vh",
+    alignItems: "center",
   },
   scrollButton: {
+    position: "fixed",
+    bottom: 12,
+    right: 12,
     width: 100,
+    zIndex: 10,
   },
   itemsContainer: {
     display: "flex",
     flexDirection: "column",
     gap: 12,
-  },
-  item: {
-    display: "flex",
-    border: "1px solid black",
-    gap: 12,
-    padding: 12,
-  },
-  firstCell: {
-    width: 180,
+    marginBottom: 60,
+    width: "90vw",
+    maxWidth: "90vw",
   },
 };
 
-type HallOfFameProps = {
-  studentId: string;
-};
-
-export const HallOfFame = ({ studentId = "6" }: HallOfFameProps) => {
+export default function HallOfFame() {
   const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
-  const scrollToStudent = () => {
-    const studentElement = document.getElementById(`student-${studentId}`);
+  const { user } = useUser();
+  const { selectedEdition } = useEditionSelection();
+
+  const { loading, error, data } = useHallOfFameQuery({
+    variables: { editionId: selectedEdition?.editionId as string },
+    skip: !selectedEdition,
+  });
+
+  const scrollToStudent = useCallback(() => {
+    const studentElement = document.getElementById(`student-${user?.userId}`);
     if (studentElement) {
-      studentElement.scrollIntoView({ behavior: "smooth" });
+      studentElement.scrollIntoView({ behavior: "smooth", block: "center" });
     }
-  };
+  }, [user?.userId]);
 
-  const students = getStudents();
-  students.sort((a: Student, b: Student) => b.level - a.level);
+  useEffect(() => {
+    if (!loading && user?.userId) {
+      scrollToStudent();
+    }
+  }, [loading, scrollToStudent, user?.userId]);
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  const students = data?.hallOfFame || [];
+
   return (
-    <div style={styles.container}>
-      <button style={styles.scrollButton} onClick={scrollToStudent}>
-        scroll to me
-      </button>
-      <div ref={containerRef} style={styles.itemsContainer}>
-        {/* TODO separate component */}
+    <div style={styles.container} ref={containerRef}>
+      <div style={styles.itemsContainer}>
+        <HallOfFameHeader />
         {students.map((s, index) => (
-          <div
-            key={s.id}
-            id={`student-${s.id}`}
-            style={{
-              ...styles.item,
-              border: s.id === studentId ? "2px solid blue" : "1px solid black",
-            }}
-          >
-            <div style={styles.firstCell}>
-              {index + 1}. {s.name}
-            </div>
-            <div>{s.level}</div>
-          </div>
+          <HallOfFameRow
+            key={s.userId}
+            student={s}
+            index={index}
+            isCurrentUser={s.userId === user?.userId}
+          />
         ))}
       </div>
+      {user.role === Roles.STUDENT && (
+        <button
+          style={styles.scrollButton}
+          ref={buttonRef}
+          onClick={scrollToStudent}
+        >
+          Moja pozycja
+        </button>
+      )}
     </div>
   );
-};
+}

--- a/frontend/src/screens/index.ts
+++ b/frontend/src/screens/index.ts
@@ -1,3 +1,0 @@
-export * from "./Welcome";
-export * from "./HallOfFame";
-export * from "./";


### PR DESCRIPTION
I've made som hallof fame rewriting. Now it uses queries from hasura. I've also splitted headers adn rows to separate components to make them more customizable later. Row component has empty field for picture - embeding pictures will come in another pr. The header is always visible at the top of the page now. Also I've made scroll to me button always visible

Demo as a teacher with multiple editions:
https://github.com/Jullija/oops/assets/70212130/16b1e12e-cf61-4259-99da-e6ff0fcbdd4e

Demo as a student
https://github.com/Jullija/oops/assets/70212130/87d17fc8-7929-48a7-beb9-cca48c744fc7

