### PR TITLE
canAddPoints category update

### DIFF
--- a/backend/src/main/kotlin/backend/categories/Categories.kt
+++ b/backend/src/main/kotlin/backend/categories/Categories.kt
@@ -13,6 +13,9 @@ class Categories(
     @Column(name = "category_name", nullable = false, length = 256)
     var categoryName: String,
 
+    @Column(name = "can_add_points", nullable = false)
+    var canAddPoints: Boolean = true,
+
     @Column(name = "label", nullable = false, length = 256)
     var label: String
 ) {

--- a/backend/src/main/kotlin/backend/graphql/AwardsDataFetcher.kt
+++ b/backend/src/main/kotlin/backend/graphql/AwardsDataFetcher.kt
@@ -3,28 +3,19 @@ package backend.graphql
 import backend.award.Award
 import backend.award.AwardRepository
 import backend.award.AwardType
-import backend.bonuses.Bonuses
 import backend.bonuses.BonusesRepository
-import backend.categories.Categories
 import backend.categories.CategoriesRepository
 import backend.edition.EditionRepository
-import backend.files.FileEntity
 import backend.files.FileEntityRepository
 import backend.groups.GroupsRepository
-import backend.levels.Levels
-import backend.points.Points
 import backend.points.PointsRepository
-import backend.subcategories.Subcategories
 import backend.subcategories.SubcategoriesRepository
 import backend.users.UsersRepository
-import backend.users.Users
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsMutation
-import com.netflix.graphql.dgs.DgsQuery
 import com.netflix.graphql.dgs.InputArgument
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
-import java.sql.Time
 
 @DgsComponent
 class AwardsDataFetcher {
@@ -71,25 +62,31 @@ class AwardsDataFetcher {
                  @InputArgument categoryId: Long, @InputArgument maxUsages: Int = -1,
                  @InputArgument label: String = ""): Award {
 
-        val awardTypeType = try {
+        val awardType1 = try {
              AwardType.valueOf(awardType)
         } catch (e: IllegalArgumentException) {
             throw IllegalArgumentException("Invalid award type")
         }
-        if (awardTypeType == AwardType.ADDITIVE && awardValue < 0) {
+        if ((awardType1 == AwardType.ADDITIVE ||
+                    awardType1 == AwardType.ADDITIVE_NEXT ||
+                    awardType1 == AwardType.ADDITIVE_PREV) && awardValue < 0) {
             throw IllegalArgumentException("Additive award value must be positive")
         }
-        if (awardTypeType == AwardType.MULTIPLICATIVE && awardValue <= 0) {
+        if (awardType1 == AwardType.MULTIPLICATIVE && awardValue <= 0) {
             throw IllegalArgumentException("Multiplicative award value must be positive")
         }
-        if (awardTypeType == AwardType.MULTIPLICATIVE && awardValue > 1) {
+        if (awardType1 == AwardType.MULTIPLICATIVE && awardValue > 1) {
             throw IllegalArgumentException("Multiplicative award value must be less than or equal to 1")
         }
         val category = categoriesRepository.findById(categoryId).orElseThrow { IllegalArgumentException("Invalid category ID") }
 
+        if (!category.canAddPoints) {
+            throw IllegalArgumentException("This category does not allow adding points from awards")
+        }
+
         val award = Award(
             awardName = awardName,
-            awardType = awardTypeType,
+            awardType = awardType1,
             awardValue = awardValue,
             category = category,
             maxUsages = maxUsages,

--- a/backend/src/main/kotlin/backend/graphql/GroupsDataFetcher.kt
+++ b/backend/src/main/kotlin/backend/graphql/GroupsDataFetcher.kt
@@ -154,7 +154,7 @@ class GroupsDataFetcher {
         }
     }
     private fun getUserCategoriesWithDefaults(categories: List<Categories>, userPoints: List<CategoryPointsType>, subcategories: List<Subcategories>): List<CategoryPointsType> {
-        return categories.map { category ->
+        return categories.filter{it.canAddPoints}.map { category ->
             userPoints.find { it.category == category } ?: CategoryPointsType(
                 category = category,
                 subcategoryPoints = subcategories.filter { it.category == category }.map { subcat ->

--- a/backend/src/main/kotlin/backend/graphql/PointsDataFetcher.kt
+++ b/backend/src/main/kotlin/backend/graphql/PointsDataFetcher.kt
@@ -43,6 +43,10 @@ class PointsDataFetcher {
         val subcategory = subcategoriesRepository.findById(subcategoryId)
             .orElseThrow { IllegalArgumentException("Invalid subcategory ID") }
 
+        if (!subcategory.category.canAddPoints) {
+            throw IllegalArgumentException("This subcategory's category does not allow adding points")
+        }
+
         if (teacher.role != UsersRoles.TEACHER && teacher.role != UsersRoles.COORDINATOR) {
             throw IllegalArgumentException("Points can be added only by teacher or coordinator")
         }

--- a/backend/src/main/kotlin/backend/graphql/UsersDataFetcher.kt
+++ b/backend/src/main/kotlin/backend/graphql/UsersDataFetcher.kt
@@ -104,7 +104,7 @@ class UsersDataFetcher {
         val bonuses = bonusesRepository.findByChestHistory_User_UserId(studentId)
         val categories = categoriesRepository.findAll()
 
-        return categories.map { category ->
+        return categories.filter{it.canAddPoints}.map { category ->
             val categoryPoints = points.filter { it.subcategory.category == category }
             val purePoints = categoryPoints.filter { bonusesRepository.findByPoints(it).isEmpty() }
             val purePointsSum = purePoints.sumOf { it.value.toDouble() }.toFloat()

--- a/backend/src/main/resources/db/migration/V34__add_can_add_points_to_category.sql
+++ b/backend/src/main/resources/db/migration/V34__add_can_add_points_to_category.sql
@@ -1,0 +1,2 @@
+ALTER TABLE categories
+    ADD COLUMN can_add_points BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/src/main/resources/schema/schema.graphql
+++ b/backend/src/main/resources/schema/schema.graphql
@@ -57,6 +57,7 @@ type BonusType {
 type CategoryType {
     categoryId: ID!
     categoryName: String!
+    canAddPoints: Boolean!
     label: String!
 }
 


### PR DESCRIPTION
Added canAddPoints to Category so that categories such as Event will be marked as chestOnly categories (canAddPoints=false) (the idea is to allow only certain categories to hold points (lab / test) and certain categories to be chest generators (event))

changed also a few of mutations to contain this bool 