### PR TITLE
[138] Added copying chests to another edition

### DIFF
--- a/backend/src/main/resources/schema/schema.graphql
+++ b/backend/src/main/resources/schema/schema.graphql
@@ -236,6 +236,10 @@ type Mutation {
   removeUser(
     userId: Int!
   ): Boolean
+  copyChest(
+    chestId: Int!,
+    editionId: Int!
+  ): ChestType
 }
 
 type Query {


### PR DESCRIPTION
```graphql
  copyChest(
    chestId: Int!,
    editionId: Int!
  ): ChestType
  ```
  when you copy a chest, the awards are inserted into the category you want the chest in 